### PR TITLE
change to assertion 4 message

### DIFF
--- a/ldmsd_auth_test
+++ b/ldmsd_auth_test
@@ -403,7 +403,7 @@ expect = set(["node-{}/{}".format(i, name) \
                     for i in [1,2,3,4] \
                     for name in ["meminfo"]])
 if sets == expect:
-    test.assert_test(4, True, "see all sets")
+    test.assert_test(4, True, "see only meminfo")
 else:
     test.assert_test(4, False, "result({}) != expect({})".format(sets, expect))
 


### PR DESCRIPTION
I believe the message for assertion 4 needs to be "only see munge" instead of "all sets".

Please let me know if this is not correct.