### PR TITLE
adding failover aggregation test

### DIFF
--- a/failover_test
+++ b/failover_test
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+
+# This is a test for failover aggregation. 
+# Please see "ldmsd_failover.man" in ovis-hpc/ovis repo. for more information.
+
+import os
+import re
+import pwd
+import sys
+import json
+import time
+import docker
+import argparse
+import TADA
+import logging
+
+from distutils.spawn import find_executable
+from LDMS_Test import LDMSDCluster, LDMSDContainer, process_args, \
+                      add_common_args, jprint, parse_ldms_ls
+
+if __name__ != "__main__":
+    raise RuntimeError("This should not be impoarted as a module.")
+
+class Debug(object):
+    pass
+D = Debug()
+
+logging.basicConfig(format = "%(asctime)s %(name)s %(levelname)s %(message)s",
+                    level = logging.INFO)
+
+log = logging.getLogger(__name__)
+
+exec(open(os.getenv("PYTHONSTARTUP", "/dev/null")).read())
+
+#### default values #### ---------------------------------------------
+sbin_ldmsd = find_executable("ldmsd")
+if sbin_ldmsd:
+    default_prefix, a, b = sbin_ldmsd.rsplit('/', 2)
+else:
+    default_prefix = "/opt/ovis"
+
+#### argument parsing #### -------------------------------------------
+ap = argparse.ArgumentParser(description = "Run test scenario of 4 samplers " \
+                             "(or more) -> 2 x agg-1 -> agg-2." )
+add_common_args(ap)
+ap.add_argument("--num-compute", type = int,
+                default = 4,
+                help = "Number of compute nodes.")
+args = ap.parse_args()
+process_args(args)
+
+#### config variables #### ------------------------------
+USER = args.user
+PREFIX = args.prefix
+COMMIT_ID = args.commit_id
+SRC = args.src
+CLUSTERNAME = args.clustername
+DB = args.data_root
+NUM_COMPUTE = args.num_compute
+LDMSD_PORT = 10000
+STORE_ROOT = "/store" # path inside container (agg-2)
+
+#### spec #### -------------------------------------------------------
+common_plugin_config = [
+        "component_id=%component_id%",
+        "instance=%hostname%/%plugin%",
+        "producer=%hostname%",
+    ]
+spec = {
+    "name" : CLUSTERNAME,
+    "description" : "{}'s test_agg cluster".format(USER),
+    "type" : "NA",
+    "templates" : { # generic template can apply to any object by "!extends"
+        "compute-node" : {
+            "daemons" : [
+                {
+                    "name" : "sshd", # for debugging
+                    "type" : "sshd",
+                },
+                {
+                    "name" : "sampler-daemon",
+                    "!extends" : "ldmsd-sampler",
+                },
+            ],
+        },
+        "sampler_plugin" : {
+            "interval" : 1000000,
+            "offset" : 0,
+            "config" : common_plugin_config,
+            "start" : True,
+        },
+        "ldmsd-base" : {
+            "type" : "ldmsd",
+            "listen" : [
+                { "port" : LDMSD_PORT, "xprt" : "sock" },
+            ],
+            #"listen_port" : LDMSD_PORT,
+            #"listen_xprt" : "sock",
+            #"listen_auth" : "none",
+        },
+        "ldmsd-sampler" : {
+            "!extends" : "ldmsd-base",
+            "samplers" : [
+                {
+                    "plugin" : "meminfo",
+                    "!extends" : "sampler_plugin",
+                },
+            ],
+        },
+        "prdcr" : {
+            "host" : "%name%",
+            "port" : LDMSD_PORT,
+            "xprt" : "sock",
+            "type" : "active",
+            "interval" : 10000000,
+        },
+        "ldmsd-aggregator" : {
+                "!extends" : "ldmsd-base",
+            "config" : [ # additional config applied after prdcrs
+                "prdcr_start_regex regex=.*",
+                "updtr_add name=all interval=1000000 offset=%offset%",
+                "updtr_prdcr_add name=all regex=.*",
+                "updtr_start name=all"]
+        },
+
+        "ldmsd-failover-agg-12" : {
+                "!extends" : "ldmsd-base",
+            "config" : [ # additional config applied after prdcrs
+                "prdcr_start_regex regex=.*",
+                "updtr_add name=all interval=1000000 offset=%offset%",
+                "updtr_prdcr_add name=all regex=.*",
+                "updtr_start name=all",
+                "failover_config host=agg-11 port=10000 xprt=sock type=active interval=1000000 timeout_factor=2",
+                "failover_start"]#last two lines are for failover config
+            },
+
+         "ldmsd-failover-agg-11" : {
+                "!extends" : "ldmsd-base",
+            "config" : [ # additional config applied after prdcrs
+                "prdcr_start_regex regex=.*",
+                "updtr_add name=all interval=1000000 offset=%offset%",
+                "updtr_prdcr_add name=all regex=.*",
+                "updtr_start name=all",
+                "failover_config host=agg-12 port=10000 xprt=sock type=active interval=1000000 timeout_factor=2", 
+                "failover_start"]
+            }
+
+ 
+    }, # templates
+    "nodes" : [
+        {
+            "hostname" : "node-{}".format(i),
+            "component_id" : i,
+            "!extends" : "compute-node",
+        } for i in range(1, NUM_COMPUTE+1)
+    ] + [
+        {
+            "hostname" : "agg-1{}".format(j),
+            "!extends" : "compute-node",
+            "daemons" : [
+                {
+                    "name" : "sshd",
+                    "type" : "sshd",
+                },
+                {
+                    "name" : "agg",
+                    "!extends" : "ldmsd-failover-agg-1{}".format(j),
+                    "offset" : 200000,
+                    "prdcrs" : [ # these producers will turn into `prdcr_add`
+                        {
+                            "name" : "node-{}".format(i*2+j),
+                            "!extends" : "prdcr",
+                        } for i in range(0, int(NUM_COMPUTE / 2))
+                    ],
+                },
+            ]
+        } for j in [1, 2]
+    ] + [
+        {
+            "hostname" : "agg-2",
+            "daemons" : [
+                {
+                    "name" : "sshd",
+                    "type" : "sshd",
+                },
+                {
+                    "name" : "aggregator",
+                    "!extends" : "ldmsd-aggregator",
+                    "offset" : 400000,
+                    "prdcrs" : [ # these producers will turn into `prdcr_add`
+                        {
+                            "name" : "agg-1{}".format(i),
+                            "!extends" : "prdcr",
+                        } for i in [1,2]
+                    ],
+                },
+            ],
+        },
+        {
+            "hostname" : "headnode",
+            "daemons" : [
+                {
+                    "name" : "sshd",
+                    "type" : "sshd",
+                },
+            ]
+        },
+    ], # nodes
+
+    #"image": "ovis-centos-build:slurm",
+    "cap_add": [ "SYS_PTRACE", "SYS_ADMIN" ],
+    "image": "ovis-centos-build",
+    "ovis_prefix": PREFIX,
+    "env" : { "FOO": "BAR" },
+    "mounts": [
+        "{}:/db:rw".format(DB),
+    ] + args.mount +
+    ( ["{0}:{0}:ro".format(SRC)] if SRC else [] ),
+}
+
+#### test definition ####
+
+test = TADA.Test(test_suite = "LDMSD",
+                 test_type = "FVT",
+                 test_name = "failover_test",
+                 test_desc = "LDMSD Failover test",
+                 test_user = args.user,
+                 commit_id = COMMIT_ID,
+                 tada_addr = args.tada_addr)
+test.add_assertion(1, "\nldms_ls agg-2")
+test.add_assertion(2, "\nmeminfo data verification")
+test.add_assertion(3, "\nagg-11 ldmsd terminated, sets added to agg-12")
+test.add_assertion(4, "\nagg-11 ldmsd terminated, all sets running on agg-2")
+test.add_assertion(5, "\nagg-11 ldmsd terminated, node-1 ldmsd is still running")
+test.add_assertion(6, "\nagg-11 ldmsd terminated, node-3 ldmsd is still running")
+test.add_assertion(7, "\nagg-11 ldmsd revived, sets removed from agg-12")
+test.add_assertion(8, "\nagg-11 ldmsd revived, all sets running on agg-2")
+test.add_assertion(9, "\nagg-12 ldmsd terminated, sets added to agg-11")
+test.add_assertion(10, "\nagg-12 ldmsd terminated, all sets running on agg-2")
+test.add_assertion(11, "\nagg-12 ldmsd terminated, node-2 ldmsd is still running")
+test.add_assertion(12, "\nagg-12 ldmsd terminated, node-4 ldmsd is still running")
+test.add_assertion(13, "\nagg-12 ldmsd revived, sets removed from agg-11")
+test.add_assertion(14, "\nagg-12 ldmsd revived, all sets running on agg-2")
+
+
+#### Helper Functions ####
+def ldms_ls(host, port = LDMSD_PORT, l = False):
+    try:
+        args = "-l -v" if l else ""
+        rc, out = headnode.exec_run("bash -c 'ldms_ls {args} -x sock -p {port}" \
+                                    "     -h {host} 2>/dev/null'" \
+                                    .format(host=host, port=port, args=args))
+        if l:
+            return parse_ldms_ls(out)
+        else:
+            return out.splitlines()
+    except:
+        return None
+#### Start! ####
+test.start()
+
+log.info("-- Get or create the cluster --")
+cluster = LDMSDCluster.get(spec["name"], create = True, spec = spec)
+
+headnode = cluster.get_container("headnode")
+agg2 = cluster.get_container("agg-2")
+agg11 = cluster.get_container("agg-11")
+agg12 = cluster.get_container("agg-12")
+node1 = cluster.get_container("node-1")
+node2 = cluster.get_container("node-2")
+node3 = cluster.get_container("node-3")
+node4 = cluster.get_container("node-4")
+
+log.info("-- Start daemons --")
+cluster.start_daemons()
+cluster.make_known_hosts()
+
+log.info("... wait a bit to make sure ldmsd's are up")
+time.sleep(8)
+
+log.info("-- ldms_ls to agg-2 --")
+result = set(ldms_ls("agg-2"))
+expect = set([ "node-{}/{}".format(i, s) \
+                    for i in range(1, NUM_COMPUTE+1) \
+                    for s in ["meminfo"] ])
+test.assert_test(1, expect == result, "dir result verified")
+
+# test.add_assertion(2, "meminfo data verification")
+sets = ldms_ls("agg-2", l=True)
+for key, _set in sets.items():
+    m = re.match(r'node-(\d+)/meminfo', key)
+    if not m:
+        test.assert_test(2, False, "Unexpected set: {}".format(key))
+        break
+    # verify component_id
+    exp_comp_id = int(m.group(1))
+    comp_id = _set['data']['component_id']
+    if exp_comp_id != comp_id:
+        test.assert_test(2, False, "Expect component_id {} but got {}"\
+                                   .format(exp_comp_id, comp_id))
+        break
+    # verify MemTotal
+    cont = cluster.get_container("node-{}".format(comp_id))
+    rc, out = cont.exec_run('grep MemTotal /proc/meminfo')
+    m = re.match(r'MemTotal:\s+(\d+)\s+kB', out)
+    if not m:
+        test.assert_test(2, False, "Error parsing /proc/meminfo")
+        break
+    exp_mem_total = int(m.group(1))
+    mem_total = _set['data']['MemTotal']
+    if exp_mem_total != mem_total:
+        test.assert_test(2, False, "Expecting MemTotal {} but got {}" \
+                                   .format(exp_mem_total, mem_total))
+        break
+else: # loop does not break
+    test.assert_test(2, True, "data verified")
+
+
+log.info("-- Terminating ldmsd on agg-11 --")
+agg11.kill_ldmsd()
+time.sleep(5)
+
+#test.add_assertion(3, "agg-11 ldmsd terminated, sets 1 and 3 added to agg-12")
+#test.add_assertion(4, "agg-11 ldmsd terminated, all sets running on agg-2")
+#test.add_assertion(5, "agg-11 ldmsd terminated, node-1 ldmsd is still running")
+#test.add_assertion(6, "agg-11 ldmsd terminated, node-3 ldmsd is still running")
+while True:
+    # pre requisite, no ldmsd on agg-11
+    c = agg11.pgrepc("ldmsd")
+    if c:
+        log.warn("ldmsd is still running on agg-11")
+        break
+
+    # agg-12
+    lst = set(ldms_ls("agg-12"))
+    expect = set([ "node-{}/{}".format(i, s) \
+                    for i in range(1, NUM_COMPUTE+1) \
+                    for s in ["meminfo"] ])
+    test.assert_test(3, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    # agg-2
+    lst = set(ldms_ls("agg-2"))
+    expect = set([ "node-{}/{}".format(i, s) \
+                    for i in range(1, NUM_COMPUTE+1) \
+                    for s in ["meminfo"] ])
+    test.assert_test(4, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    # node-1
+    lst = set(ldms_ls("node-1"))
+    expect = set(["node-1/meminfo"])
+    test.assert_test(5, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    # node-3
+    lst = set(ldms_ls("node-3"))
+    expect = set(["node-3/meminfo"])
+    test.assert_test(6, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    break
+
+
+log.info("-- Resurrecting ldmsd on agg-11 --")
+agg11.start_ldmsd()
+time.sleep(5)
+
+#test.add_assertion(7, "agg-11 ldmsd revived, sets removed from agg-12")
+#test.add_assertion(8, "agg-11 ldmsd revived, all sets running on agg-2")
+while True:
+    c = agg11.pgrepc("ldmsd")
+    if not c:
+        log.warn("ldmsd on agg-11 was not up")
+        break
+    
+    # agg-12
+    lst = set(ldms_ls("agg-12"))
+    expect = set([ "node-{}/{}".format(i, s) \
+                    for i in range(2, NUM_COMPUTE+1, 2) \
+                    for s in ["meminfo"] ])
+    test.assert_test(7, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    # agg-2
+    lst = set(ldms_ls("agg-2"))
+    expect = set([ "node-{}/{}".format(i, s) \
+                    for i in range(1, NUM_COMPUTE+1) \
+                    for s in ["meminfo"] ])
+    test.assert_test(8, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    break
+
+
+log.info("-- Terminating ldmsd on agg-12 --")
+agg12.kill_ldmsd()
+time.sleep(5)
+
+#test.add_assertion(9, "agg-11 ldmsd terminated, sets added to agg-12")
+#test.add_assertion(10, "agg-11 ldmsd terminated, all sets running on agg-2")
+#test.add_assertion(11, "agg-11 ldmsd terminated, node-2 ldmsd is still running")
+#test.add_assertion(12, "agg-11 ldmsd terminated, node-4 ldmsd is still running")
+while True:
+    # pre requisite, no ldmsd on agg-11
+    c = agg12.pgrepc("ldmsd")
+    if c:
+        log.warn("ldmsd is still running on agg-12")
+        break
+
+    # agg-11
+    lst = set(ldms_ls("agg-11"))
+    expect = set([ "node-{}/{}".format(i, s) \
+                    for i in range(1, NUM_COMPUTE+1) \
+                    for s in ["meminfo"] ])
+    test.assert_test(9, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    # agg-2
+    lst = set(ldms_ls("agg-2"))
+    expect = set([ "node-{}/{}".format(i, s) \
+                    for i in range(1, NUM_COMPUTE+1) \
+                    for s in ["meminfo"] ])
+    test.assert_test(10, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    # node-2
+    lst = set(ldms_ls("node-2"))
+    expect = set(["node-2/meminfo"])
+    test.assert_test(11, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    # node-4
+    lst = set(ldms_ls("node-4"))
+    expect = set(["node-4/meminfo"])
+    test.assert_test(12, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    break
+
+
+log.info("-- Resurrecting ldmsd on agg-12 --")
+agg12.start_ldmsd()
+time.sleep(5)
+
+#test.add_assertion(13, "agg-11 ldmsd revived, sets removed from agg-12")
+#test.add_assertion(14, "agg-11 ldmsd revived, all sets running on agg-2")
+while True:
+    c = agg12.pgrepc("ldmsd")
+    if not c:
+        log.warn("ldmsd on agg-12 was not up")
+        break
+    
+    # agg-11
+    lst = set(ldms_ls("agg-11"))
+    expect = set([ "node-{}/{}".format(i, s) \
+                    for i in range(1, NUM_COMPUTE+1, 2) \
+                    for s in ["meminfo"] ])
+    test.assert_test(13, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    # agg-2
+    lst = set(ldms_ls("agg-2"))
+    expect = set([ "node-{}/{}".format(i, s) \
+                    for i in range(1, NUM_COMPUTE+1) \
+                    for s in ["meminfo"] ])
+    test.assert_test(14, lst == expect, "list({}) == expect({})" \
+                                       .format(lst, expect))
+    break
+
+
+test.finish()
+cluster.remove() # this destroys entire cluster


### PR DESCRIPTION
This script tests the failover of two level-1 aggregators (agg-11 and agg-12). A level-2 aggregator is used to check all sets exist.   
The test ran successfully within a VM containing the ldms-test infrastructure.

Please let me know if there are any issues.