### PR TITLE
Update the test scripts that use the test_sampler plugin

### DIFF
--- a/scalability/ldmsdutils.py
+++ b/scalability/ldmsdutils.py
@@ -588,7 +588,7 @@ load name=test_sampler
 config name=test_sampler action=add_schema schema=test num_metrics=2 type=U64
 """ + \
 "".join("""\
-config name=test_sampler action=add_set instance={{name}}/set_{} schema=test component_id={{id}}
+config name=test_sampler action=add_set instance={{name}}/set_{} schema=test component_id={{id}} producer={{name}}
 """.format(i) for i in range(0, SETS_PER_SAMP)) \
 + \
 """


### PR DESCRIPTION
The test_sampler plugin changed the configuration so that the producer
attribute is required with action=add_set.