### PR TITLE
Update create_updtr_status() API

### DIFF
--- a/LDMS_Test.py
+++ b/LDMS_Test.py
@@ -2672,7 +2672,8 @@ def assertion_id_get():
         id += 1
 
 def create_updtr_status(name, interval, offset, state, prdcrs,
-                        sync = True, mode = "Pull", auto = False):
+                        sync = True, mode = "Pull", auto = False,
+                        outstanding = 0, oversampled = 0):
     return {'name' : name,
              'interval' : str(interval),
              'offset' : str(offset),
@@ -2680,7 +2681,9 @@ def create_updtr_status(name, interval, offset, state, prdcrs,
              'mode' : mode,
              'auto' : "true" if auto else "false",
              'state' : state,
-             'producers' : prdcrs}
+             'producers' : prdcrs,
+             'outstanding count' : outstanding,
+             'oversampled count' : oversampled}
 
 def create_updtr_prdcr_status(name, host, port, xprt, state):
     return {'name' : name,


### PR DESCRIPTION
LDMSD's updtr_status() has been updated to include the overstanding and oversampled counters. The patch updates the LDMS_Test module's create_updtr_status() API to be consistent with LDMSD's updtr_status.

The caller calls create_updtr_status() to generate the updtr_status's result.