### PR TITLE
Make test-all.sh to report the tests run by run_inside_cont_test.sh

### DIFF
--- a/test-all.sh
+++ b/test-all.sh
@@ -46,6 +46,18 @@ for T in ${LIST[*]}; do
 	echo "----------------------------------------------"
 done
 
+for T in ${INSIDE_CONT_TEST_LIST[*]}; do
+	echo "======== ${T} ========"
+	CMD="./run_inside_cont_test.py --suite ${T} $@"
+	echo ${CMD}
+	${CMD}
+	RC=$?
+	RCS["$T"]=${RC}
+	echo "EXIT_CODE: ${RC}"
+	sleep 10 # allow some clean-up break between tests
+	echo "----------------------------------------------"
+done
+
 export RED='\033[01;31m'
 export GREEN='\033[01;32m'
 export RESET='\033[0m'

--- a/test-list.sh
+++ b/test-list.sh
@@ -50,13 +50,18 @@ CONT_TEST_LIST=(
 	ldmsd_flex_decomp_test
 	ldms_set_info_test
 	slurm_sampler2_test
-	run_inside_cont_test.py
 	libovis_log_test
 	ldmsd_long_config_test
 	ldms_rail_test
 	ldms_stream_test
 	set_sec_mod_test
 	dump_cfg_test
+)
+
+INSIDE_CONT_TEST_LIST=(
+	prdcr_config_cmd_test
+	strgp_config_cmd_test
+	plugin_config_cmd_test
 )
 
 # List of direct (non-containerized, running on host) tests


### PR DESCRIPTION
Before the patch, the passed test count on the Github is not accurate. The test-all.sh script does not individually report the results of the tests reside in the inside_cont_test directory. The patch corrects the reported count.